### PR TITLE
fix: getting starting subsection + example links 

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -63,11 +63,10 @@ layout: default
           </a>
         </div>
         <ul class="nav-subsection {% if page.url contains '/getting-started/' %}expanded{% endif %}" id="getting-started-section">
-          <li><a href="{{ '/docs/getting-started/' | relative_url }}#a-instructions-architecture" class="nav-sub-link">A. Instructions Architecture</a></li>
-          <li><a href="{{ '/docs/getting-started/' | relative_url }}#b-chat-modes-configuration" class="nav-sub-link">B. Chat Modes Configuration</a></li>
-          <li><a href="{{ '/docs/getting-started/' | relative_url }}#c-agentic-workflows" class="nav-sub-link">C. Agentic Workflows</a></li>
-          <li><a href="{{ '/docs/getting-started/' | relative_url }}#d-specification-templates" class="nav-sub-link">D. Specification Templates</a></li>
-          <li><a href="{{ '/docs/getting-started/' | relative_url }}#e-context-organization--discovery" class="nav-sub-link">E. Context Organization</a></li>
+          <li><a href="{{ '/docs/getting-started/' | relative_url }}#instructions-architecture" class="nav-sub-link">A. Instructions Architecture</a></li>
+          <li><a href="{{ '/docs/getting-started/' | relative_url }}#chat-modes-configuration" class="nav-sub-link">B. Chat Modes Configuration</a></li>
+          <li><a href="{{ '/docs/getting-started/' | relative_url }}#agentic-workflows" class="nav-sub-link">C. Agentic Workflows</a></li>
+          <li><a href="{{ '/docs/getting-started/' | relative_url }}#specification-templates" class="nav-sub-link">D. Specification Templates</a></li>
           <li><a href="{{ '/docs/getting-started/' | relative_url }}#quick-start-checklist" class="nav-sub-link">Quick Start Checklist</a></li>
         </ul>
       </div>

--- a/docs/agent-delegation/index.md
+++ b/docs/agent-delegation/index.md
@@ -384,6 +384,6 @@ The most sophisticated approach combines local control with async delegation thr
 
 **Ready to scale to teams?** Continue to [Team & Enterprise Scale](../team-adoption/) to bridge from individual mastery to team coordination through spec-driven workflows and enterprise governance.
 
-**Need implementation templates?** Check out the [Examples](../examples/) for ready-to-use primitives.
+**Need implementation templates?** Check out the [Examples](../../examples/) for ready-to-use primitives.
 
 *You now have complete agentic workflow patterns and delegation strategies. The next step is scaling these techniques across your entire organization.*

--- a/docs/team-adoption/index.md
+++ b/docs/team-adoption/index.md
@@ -739,6 +739,6 @@ You don't need radical restructuring. You need systematic application of the Age
 
 **Want quick reference materials?** Jump to [Reference](../reference/) for checklists and implementation templates.
 
-**Looking for concrete examples?** Check out the [Examples](../../_examples/) for ready-to-use team primitives and spec-driven workflow templates.
+**Looking for concrete examples?** Check out the [Examples](../../examples/) for ready-to-use team primitives and spec-driven workflow templates.
 
 *You now have the frameworks to scale AI Native Development from individual mastery to team coordination to enterprise governance—preserving productivity gains while maintaining quality, compliance, and systematic knowledge accumulation.*


### PR DESCRIPTION

This pull request makes small but important improvements to documentation navigation and internal links. The main focus is on fixing broken or incorrect links to ensure users can navigate the documentation smoothly.

Navigation and link fixes:

* Updated anchor links in the getting started navigation menu in `_layouts/docs.html` to remove unnecessary prefixes (like `a-`, `b-`, etc.) so they match the actual section IDs in the documentation.
* Fixed relative links to the `examples` directory in `docs/agent-delegation/index.md` and `docs/team-adoption/index.md` so they correctly point to `../../examples/` instead of incorrect or outdated paths. [[1]](diffhunk://#diff-fd9a71c8bdb75f4a28fb4001499c60a6a7822d62a41fecb9ade05245db2ef4fcL387-R387) [[2]](diffhunk://#diff-ed22d66e31eb285c08b8d403d82f4595d3029e663d6859c12dc90d0503caff72L742-R742)