### PR TITLE
Phase 1: Reposition site as Copilot-native practitioner playbook + handbook funnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
-# 🎯 PROSE for AI Native Development
+# PROSE
 
-*This repository has been restructured as a comprehensive GitHub Pages site for better navigation and content extraction. The complete guide is now available at: **[https://danielmeppiel.github.io/awesome-ai-native](https://danielmeppiel.github.io/awesome-ai-native)***
+### Build agentic primitives for GitHub Copilot.
+
+Skills, Custom Agents, Instructions, and Hooks — designed with proven architectural patterns, bundled into plugins, and shipped on marketplaces. Hands-on. Copilot-native. Practitioner-tested.
+
+**[Start building →](https://danielmeppiel.github.io/awesome-ai-native/docs/getting-started/)** &nbsp;·&nbsp; **[Read the Specification →](https://danielmeppiel.github.io/agentic-sdlc-handbook/handbook/ch12-the-prose-specification.html)**
 
 ---
 
-## PROSE for AI Native Development
+> **The book teaches the discipline. This site shows you how to ship it in Copilot.**
+>
+> [*The Agentic SDLC Handbook*](https://danielmeppiel.github.io/agentic-sdlc-handbook/) is the in-depth reference for PROSE — the seven primitive types, the load lifecycle, the architectural patterns, the methodology. This site is the practitioner's playbook: how to author Skills, Custom Agents, Instructions, and Hooks for Copilot, bundle them as plugins, and distribute them. Theory there. Practice here.
 
-**Programming has evolved.** From Assembly to Python, each abstraction brought us closer to human thought. Now we've reached the final layer: *prose itself becomes executable.*
+---
+
+## PROSE — the five constraints
 
 | | Constraint | Principle | Induced Property |
 |---|------------|-----------|------------------|

--- a/_includes/announcement.html
+++ b/_includes/announcement.html
@@ -1,0 +1,19 @@
+<div class="announcement-bar" id="announcement-bar" role="region" aria-label="Site announcement">
+  <div class="announcement-inner">
+    <p class="announcement-text">
+      New: <em>The Agentic SDLC Handbook</em> — the in-depth reference for PROSE. Free, online.
+      <a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/" target="_blank" rel="noopener noreferrer">Read it →</a>
+    </p>
+    <button type="button" class="announcement-close" aria-label="Dismiss announcement" onclick="(function(){document.getElementById('announcement-bar').style.display='none';try{localStorage.setItem('apm-announce-dismissed','1')}catch(e){}})();return false;">×</button>
+  </div>
+</div>
+<script>
+  (function() {
+    try {
+      if (localStorage.getItem('apm-announce-dismissed') === '1') {
+        var el = document.getElementById('announcement-bar');
+        if (el) el.style.display = 'none';
+      }
+    } catch (e) {}
+  })();
+</script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,10 +1,11 @@
 <footer class="site-footer">
   <div class="wrapper">
     <div class="footer-content">
+      <p class="footer-companion">The book is the theory. This site is the Copilot practice. <a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/" target="_blank" rel="noopener noreferrer">Read the Handbook →</a></p>
       <p class="footer-contribute">Shaped by practitioners. <a href="https://github.com/danielmeppiel/awesome-ai-native">Contribute on GitHub</a></p>
       <p class="footer-text">
-        © {{ 'now' | date: '%Y' }} {{ site.author }} · 
-        <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA 4.0</a> · 
+        © {{ 'now' | date: '%Y' }} {{ site.author }} ·
+        <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">CC BY-SA 4.0</a> ·
         <a href="{{ '/about/' | relative_url }}">About</a>
       </p>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -28,9 +28,7 @@
       </a>
       
       <!-- Primary CTA -->
-      {% unless page.layout == 'docs' %}
-        <a href="{{ '/docs/prose/' | relative_url }}" class="btn-primary">Read the Spec</a>
-      {% endunless %}
+      <a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/" class="btn-primary" target="_blank" rel="noopener noreferrer">Read the Handbook</a>
       </div>
     </nav>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
 
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
+    {%- include announcement.html -%}
     {%- include header.html -%}
 
     <main id="main-content" class="page-content" aria-label="Content">

--- a/about.md
+++ b/about.md
@@ -8,12 +8,13 @@ permalink: /about/
   <div class="about-profile">
     <img src="https://github.com/danielmeppiel.png" alt="Daniel Meppiel" class="profile-avatar" />
     <h1>Daniel Meppiel</h1>
-    <p class="profile-tagline">Developer and founder focused on developer experience and AI-native tooling.</p>
-    <p class="profile-role">Sr. Global Black Belt - Software at Microsoft</p>
-    <p class="profile-history">Previously at GitHub, Sonar, and startup founder.</p>
+    <p class="profile-tagline">Sr. Global Black Belt – Software at Microsoft. Previously at GitHub, Sonar, and startup founder.</p>
+    <p class="profile-pointer">Full bio, writing, and links at <a href="https://theainativemind.com" target="_blank" rel="noopener noreferrer">theainativemind.com</a>.</p>
     <div class="profile-links">
-      <a href="https://github.com/danielmeppiel">GitHub</a>
-      <a href="https://www.linkedin.com/in/danielmeppiel/">LinkedIn</a>
+      <a href="https://theainativemind.com" target="_blank" rel="noopener noreferrer">theainativemind.com</a>
+      <a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/" target="_blank" rel="noopener noreferrer">The Agentic SDLC Handbook</a>
+      <a href="https://github.com/danielmeppiel" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://www.linkedin.com/in/danielmeppiel/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
     </div>
   </div>
 
@@ -21,9 +22,8 @@ permalink: /about/
 
   <div class="about-content">
     <h2>About PROSE</h2>
-    <p>PROSE is an architectural style for AI-native development, born from practical experience with GitHub Copilot and AI coding assistants.</p>
-    <p>After working with teams adopting AI tools, I noticed a pattern: success came not from the tools themselves, but from how teams structured their work. PROSE codifies these patterns as actionable constraints.</p>
-    
+    <p>PROSE is an architectural style for AI-native development, born from practical experience with GitHub Copilot and AI coding assistants. The in-depth reference treatment now lives in <a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/" target="_blank" rel="noopener noreferrer"><em>The Agentic SDLC Handbook</em></a> (Chapter 12). This site is the practitioner's playbook for building Copilot primitives — Skills, Custom Agents, Instructions, and Hooks — and shipping them as plugins.</p>
+
     <h2>Why I Built This</h2>
     <p>This project is my way of giving back to the developer community that shaped my career. The ideas here emerged from countless conversations with developers, and I'm sharing them openly so others can benefit—and improve on them.</p>
     <p>I believe the best frameworks are co-created. Your feedback, contributions, and real-world experiences will make PROSE better. This is open source at its core: a starting point for collective learning, not a finished product.</p>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -3112,3 +3112,239 @@ a.github-btn:hover {
     max-width: 280px;
   }
 }
+
+/* ============================================
+   Phase 1 — Handbook funnel: announcement bar,
+   hero subtitle + dual CTA, positioning callout,
+   primitive grid, footer companion line.
+   ============================================ */
+
+.announcement-bar {
+  background: var(--primary-color, #0969da);
+  color: #ffffff;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.announcement-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  position: relative;
+}
+
+.announcement-text {
+  margin: 0;
+  text-align: center;
+  color: #ffffff;
+}
+
+.announcement-text em {
+  font-style: italic;
+}
+
+.announcement-text a {
+  color: #ffffff !important;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  margin-left: 6px;
+  font-weight: 600;
+}
+
+.announcement-text a:hover {
+  text-decoration: none;
+}
+
+.announcement-close {
+  background: transparent;
+  border: none;
+  color: #ffffff;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.85;
+}
+
+.announcement-close:hover {
+  opacity: 1;
+}
+
+@media (max-width: 640px) {
+  .announcement-inner {
+    padding: 10px 36px 10px 16px;
+  }
+  .announcement-text {
+    font-size: 0.85rem;
+  }
+}
+
+/* Hero subtitle (between H1 and tagline) */
+.hero-section .hero-subtitle {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  max-width: 640px;
+  margin: 0 auto 12px auto;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+@media (max-width: 768px) {
+  .hero-section .hero-subtitle {
+    font-size: 1.2rem;
+  }
+}
+
+.hero-section .tagline {
+  max-width: 640px;
+}
+
+/* Dual CTA row */
+.hero-ctas {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 0;
+}
+
+.hero-cta--secondary {
+  background: transparent !important;
+  color: var(--primary-color) !important;
+  border: 1px solid var(--border-color, #d0d7de);
+}
+
+.hero-cta--secondary:hover {
+  background: var(--bg-subtle, #f6f8fa) !important;
+  color: var(--primary-color) !important;
+}
+
+.hero-cta--secondary:visited {
+  color: var(--primary-color) !important;
+}
+
+/* Positioning callout (book vs site) */
+.positioning-callout {
+  max-width: 760px;
+  margin: 24px auto 48px auto;
+  padding: 24px 28px;
+  background: var(--bg-subtle, #f6f8fa);
+  border: 1px solid var(--border-color, #d0d7de);
+  border-radius: 8px;
+}
+
+.positioning-lead {
+  margin: 0 0 10px 0;
+  font-size: 1.05rem;
+  color: var(--text-primary);
+}
+
+.positioning-body {
+  margin: 0;
+  font-size: 0.975rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* Primitive grid */
+.primitive-grid {
+  max-width: 1040px;
+  margin: 0 auto 56px auto;
+  padding: 0 20px;
+}
+
+.primitive-grid-title {
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0 0 24px 0;
+  color: var(--text-primary);
+  border-bottom: none !important;
+}
+
+.primitive-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 900px) {
+  .primitive-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .primitive-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.primitive-card {
+  background: #ffffff;
+  border: 1px solid var(--border-color, #d0d7de);
+  border-radius: 8px;
+  padding: 18px 20px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primitive-card:hover {
+  border-color: var(--primary-color, #0969da);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.primitive-card h3 {
+  margin: 0 0 8px 0 !important;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  border-bottom: none !important;
+}
+
+.primitive-card p {
+  margin: 0;
+  font-size: 0.925rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.primitive-card a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.primitive-card a:hover {
+  text-decoration: underline;
+}
+
+/* Footer companion line */
+.site-footer .footer-companion {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  margin: 0 0 8px 0;
+}
+
+.site-footer .footer-companion a {
+  font-weight: 600;
+}
+
+/* About page profile pointer */
+.about-profile .profile-pointer {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  margin: 8px 0 16px 0;
+}
+
+.about-profile .profile-pointer a {
+  color: var(--primary-color);
+}

--- a/index.md
+++ b/index.md
@@ -6,14 +6,55 @@ permalink: /
 
 <div class="hero-section">
   <h1>PROSE</h1>
-  <p class="tagline">An architectural style for AI-native development</p>
-  <a href="docs/prose/" class="hero-cta">Read the Specification →</a>
+  <p class="hero-subtitle">Build agentic primitives for GitHub Copilot.</p>
+  <p class="tagline">Skills, Custom Agents, Instructions, and Hooks — designed with proven architectural patterns, bundled into plugins, and shipped on marketplaces. Hands-on. Copilot-native. Practitioner-tested.</p>
+  <p class="hero-ctas">
+    <a href="docs/getting-started/" class="hero-cta">Start building →</a>
+    <a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/handbook/ch12-the-prose-specification.html" class="hero-cta hero-cta--secondary" target="_blank" rel="noopener noreferrer">Read the Specification →</a>
+  </p>
   <p class="hero-meta">Open source · Contributions welcome</p>
 </div>
 
+<div class="positioning-callout">
+  <p class="positioning-lead"><strong>The book teaches the discipline. This site shows you how to ship it in Copilot.</strong></p>
+  <p class="positioning-body"><a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/"><em>The Agentic SDLC Handbook</em></a> is the in-depth reference for PROSE — the seven primitive types, the load lifecycle, the architectural patterns, the methodology. This site is the practitioner's playbook: how to author Skills, Custom Agents, Instructions, and Hooks for Copilot, bundle them as plugins, and distribute them. Theory there. Practice here.</p>
+</div>
+
+<div class="primitive-grid">
+  <h2 class="primitive-grid-title">What you'll find here</h2>
+  <div class="primitive-cards">
+    <div class="primitive-card">
+      <h3>Skills</h3>
+      <p>The new entrypoint. Description-driven activation. (Chatmodes are deprecated.)</p>
+    </div>
+    <div class="primitive-card">
+      <h3>Custom Agents</h3>
+      <p>Specialist personas with tool boundaries. Sub-agents you can dispatch.</p>
+    </div>
+    <div class="primitive-card">
+      <h3>Instructions</h3>
+      <p>Scoped conventions per file or directory.</p>
+    </div>
+    <div class="primitive-card">
+      <h3>Hooks</h3>
+      <p>Event-driven automation on dev events.</p>
+    </div>
+    <div class="primitive-card">
+      <h3>Plugins</h3>
+      <p>Bundle primitives, ship them on marketplaces.</p>
+    </div>
+    <div class="primitive-card">
+      <h3>Patterns</h3>
+      <p>The architectural and design-pattern vocabulary that makes primitives durable — grounded in the <a href="https://danielmeppiel.github.io/agentic-sdlc-handbook/handbook/ch18-architectural-patterns-rosetta-stone.html">Rosetta Stone chapter</a> and the <a href="https://github.com/danielmeppiel/genesis">genesis skill</a>.</p>
+    </div>
+  </div>
+</div>
+
 <div class="beyond-section">
-  <p class="beyond-title">Beyond the specification</p>
+  <p class="beyond-title">Browse the existing material</p>
   <p class="beyond-links">
+    <a href="docs/prose/">PROSE Spec</a>
+    <span class="sep">·</span>
     <a href="docs/concepts/">The Practice</a>
     <span class="sep">·</span>
     <a href="docs/getting-started/">Getting Started</a>


### PR DESCRIPTION
Repositions `awesome-ai-native` against [*The Agentic SDLC Handbook*](https://danielmeppiel.github.io/agentic-sdlc-handbook/) so the two properties stop competing and start compounding.

## The thesis

- **Book** = theory, methodology, the seven primitive types, the spec.
- **Site** = how to ship it in Copilot — Skills, Custom Agents, Instructions, Hooks, bundled into plugins, distributed via marketplaces.

The site historically converted to nothing. The book is now the canonical theory home (Ch12 is the in-depth PROSE spec). This PR wires a funnel that captures both intents — *"I want to build"* (stays on-site) and *"I want the spec first"* (jumps to the book) — without making either property feel like a billboard for the other.

## Funnel surfaces

| Surface | Job | Destination |
|---|---|---|
| Announcement bar (dismissible, localStorage) | Awareness | Handbook home |
| Header pill *Read the Handbook* | Sitewide persistent CTA | Handbook home |
| Hero primary *Start building →* | Capture practical intent, keep on-site | `/docs/getting-started/` |
| Hero secondary *Read the Specification →* | Capture theory-first intent | Handbook Ch12 |
| Positioning callout below hero | Reinforce the division of labor | Handbook home |
| Six-card primitive grid | Show what the site teaches | On-site |
| Footer companion line | Last reminder | Handbook home |

Five surfaces feed the book; one earns the click that keeps practitioners on-property.

## What changed

- **`index.md`** — new hero (subtitle "Build agentic primitives for GitHub Copilot."), dual CTAs, positioning callout, primitive grid (Skills noted as the new entrypoint; chatmodes deprecated), slimmer "Browse the existing material" strip.
- **`_includes/announcement.html`** *(new)* — dismissible top banner, localStorage key `apm-announce-dismissed`.
- **`_layouts/default.html`** — includes the announcement above the header.
- **`_includes/header.html`** — replaces "Read the Spec" pill with "Read the Handbook" (sitewide).
- **`_includes/footer.html`** — adds: *"The book is the theory. This site is the Copilot practice. Read the Handbook →"*
- **`about.md`** — bio points to theainativemind.com as primary destination; About PROSE paragraph references handbook Ch12 as the in-depth reference.
- **`README.md`** — top hero rewritten to mirror the site (no emojis); rest of README untouched.
- **`assets/main.scss`** — Phase 1 styles for `.announcement-bar`, `.hero-subtitle`, `.hero-ctas`, `.hero-cta--secondary`, `.positioning-callout`, `.primitive-grid`/`.primitive-cards`/`.primitive-card`, `.footer-companion`, `.profile-pointer`, plus mobile breakpoints.

## Constraints honored

- No emojis, no "canonical", no "corpus".
- Repo name unchanged (SEO equity).
- About page kept (not 301'd) per the "give people a path" preference.
- No changes to the `docs/` tree — content rewrite is Phase 2.

## What's deliberately not in this PR

- Tutorial spine (Skills → Plugins → Patterns) — Phase 2.
- Email capture (Kit form from handbook growth engine) — Phase 2/3.
- README sections below the new hero (still emoji-heavy) — out of Phase 1 scope.

## How to verify locally

```bash
export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
bundle install
bundle exec jekyll serve --port 4000 --host 127.0.0.1 --no-watch
# open http://127.0.0.1:4000/awesome-ai-native/
```

Click both hero CTAs, dismiss the announcement bar and reload (it should stay dismissed), visit `/about/`, and check the header pill on a deep page.

---

🤖 Phase 1 of the strategic repositioning. Phase 2 (tutorial spine) and Phase 3 (distribution) tracked separately.